### PR TITLE
Fix custom profiles

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 AWeber Communications
+Copyright (c) 2015-2016 AWeber Communications
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,9 @@
 Version History
 ===============
 
+Next Release
+------------
+ - Correctly support region lookup for non-default profiles.
 
 0.4.4 (2016-04-01)
 ------------------

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -18,6 +18,12 @@ class BaseTestCase(unittest.TestCase):
 
 class ClientConfigTestCase(BaseTestCase):
 
+    def setUp(self):
+        super(ClientConfigTestCase, self).setUp()
+        os.environ.pop('AWS_CONFIG_FILE', None)
+        os.environ.pop('AWS_SHARED_CREDENTIALS_FILE', None)
+        os.environ.pop('AWS_DEFAULT_PROFILE', None)
+
     def test_passed_in_values(self):
         region = uuid.uuid4().hex
         access_key = uuid.uuid4().hex
@@ -26,7 +32,7 @@ class ClientConfigTestCase(BaseTestCase):
                               access_key=access_key, secret_key=secret_key)
         self.assertEqual(obj._region, region)
 
-    def test_with_valid_config_specified_profile(self):
+    def test_with_valid_config_default_profile(self):
         cfg = {
             'default': {
                 'region': uuid.uuid4().hex
@@ -49,6 +55,38 @@ class ClientConfigTestCase(BaseTestCase):
                 os.environ['AWS_SHARED_CREDENTIALS_FILE'] = handle.name
                 obj = self.get_client('dynamodb')
                 self.assertEqual(cfg['default']['region'], obj._region)
+
+    def test_with_valid_config_specified_profile(self):
+        cfg = {
+            'default': {
+                'region': uuid.uuid4().hex
+            },
+            'profile custom': {
+                'region': uuid.uuid4().hex
+            }
+        }
+
+        creds = {
+            'default': {
+                'aws_access_key_id': uuid.uuid4().hex,
+                'aws_secret_access_key': uuid.uuid4().hex
+            },
+            'custom': {
+                'aws_access_key_id': uuid.uuid4().hex,
+                'aws_secret_access_key': uuid.uuid4().hex
+            }
+        }
+        with tempfile.NamedTemporaryFile() as config_handle:
+            config_handle.write(utils.build_ini(cfg))
+            config_handle.flush()
+            os.environ['AWS_CONFIG_FILE'] = config_handle.name
+            os.environ['AWS_DEFAULT_PROFILE'] = 'custom'
+            with tempfile.NamedTemporaryFile() as handle:
+                handle.write(utils.build_ini(creds))
+                handle.flush()
+                os.environ['AWS_SHARED_CREDENTIALS_FILE'] = handle.name
+                obj = self.get_client('dynamodb')
+                self.assertEqual(cfg['profile custom']['region'], obj._region)
 
 
 

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -57,7 +57,7 @@ class GetRegionTestCase(unittest.TestCase):
             'default': {
                 'region': uuid.uuid4().hex
             },
-            'foo': {
+            'profile foo': {
                 'region': uuid.uuid4().hex
             }
         }
@@ -66,7 +66,7 @@ class GetRegionTestCase(unittest.TestCase):
             handle.flush()
             os.environ['AWS_CONFIG_FILE'] = handle.name
             value = config.get_region('foo')
-            self.assertEqual(expectation['foo']['region'], value)
+            self.assertEqual(expectation['profile foo']['region'], value)
 
     @unittest.skipIf(os.environ.get('TRAVIS') == 'true',
                      'Skipping this test on Travis CI.')

--- a/tornado_aws/client.py
+++ b/tornado_aws/client.py
@@ -101,7 +101,7 @@ class AWSClient(object):
                  access_key=None, secret_key=None, endpoint=None):
         self._service = service
         self._profile = profile or os.getenv('AWS_DEFAULT_PROFILE', 'default')
-        self._region = region or config.get_region(profile)
+        self._region = region or config.get_region(self._profile)
         self._client = self._get_client_adapter()
         self._auth_config = config.Authorization(self._profile, access_key,
                                                  secret_key, self._client)

--- a/tornado_aws/config.py
+++ b/tornado_aws/config.py
@@ -53,9 +53,10 @@ def get_region(profile):
                          error)
             raise exceptions.ConfigNotFound(path=file_path)
 
-    if profile not in config and 'default' not in config:
+    key = 'profile {0}'.format(profile)
+    if key not in config and 'default' not in config:
         raise exceptions.NoProfileError(path=file_path, profile=profile)
-    return (config.get(profile, {}).get('region') or
+    return (config.get(key, {}).get('region') or
             config.get('default', {}).get('region') or
             DEFAULT_REGION)
 


### PR DESCRIPTION
Custom profile sections use "profile " + name in the configuration file and tornado_aws wasn't doing that.  http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles describes the configuration file key names.
