### PR TITLE
Add RequestException

### DIFF
--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -393,7 +393,7 @@ class ClientFetchTestCase(MockTestCase):
             with mock.patch.object(obj._client, 'fetch') as fetch:
                 fetch.side_effect = OSError()
                 body = json.dumps({'foo': 'bar'})
-                with self.assertRaises(exceptions.AWSClientException):
+                with self.assertRaises(exceptions.RequestException):
                     obj.fetch('POST', '/', body=body)
 
     def test_fetch_no_headers(self):
@@ -636,7 +636,7 @@ class AsyncClientFetchTestCase(MockTestCase, utils.AsyncHTTPTestCase):
                 future = concurrent.Future()
                 future.set_exception(OSError)
                 fetch.return_value = future
-                with self.assertRaises(exceptions.AWSClientException):
+                with self.assertRaises(exceptions.RequestException):
                     yield obj.fetch('GET', '/api')
 
 

--- a/tornado_aws/client.py
+++ b/tornado_aws/client.py
@@ -171,7 +171,7 @@ class AWSClient(object):
             return result
         except (OSError, socket.error) as error:
             LOGGER.error('Error making request: %s', error)
-            raise exceptions.AWSClientException()
+            raise exceptions.RequestException(error=error)
         except httpclient.HTTPError as error:
             need_credentials, aws_error = self._process_error(error)
             if need_credentials and not self._auth_config.local_credentials:
@@ -601,7 +601,7 @@ class AsyncAWSClient(AWSClient):
                     future.set_exception(aws_error if aws_error else exception)
                 else:
                     LOGGER.error('Error making request: %s', exception)
-                    future.set_exception(exceptions.AWSClientException())
+                    future.set_exception(exceptions.RequestException(error=exception))
             else:
                 future.set_result(response.result())
 

--- a/tornado_aws/exceptions.py
+++ b/tornado_aws/exceptions.py
@@ -69,3 +69,12 @@ class NoProfileError(AWSClientException):
 
     """
     fmt = 'Profile ({profile}) not found ({path})'
+
+
+class RequestException(AWSClientException):
+    """Raised when a request failed due to a network issue.
+
+    :ivar error: The error which occured
+
+    """
+    fmt = 'An error occured making a request {error}'


### PR DESCRIPTION
This exception is raised when a network issues occurs while making a request. This allows for finer handling of network-only issues without also handling anything that inherits from AWSClientException. 

For example, this new exception is useful when implementing request retry logic.
